### PR TITLE
Create admin commands (/admin setchannel, /admin setrequirement, /admin setrole)

### DIFF
--- a/commands/moderation/adminCommands.js
+++ b/commands/moderation/adminCommands.js
@@ -33,10 +33,10 @@ async function handleSetRequirement(interaction, messageEmbed) {
     const newRequirement = interaction.options.getInteger(REQUIREMENT_OPTION_NAME);
     
     if (settingVeteranReq) {
-        messageEmbed.setDescription(`The requirement for the veteran feedback role has been set to ${newRequirement}.`);
+        messageEmbed.setDescription(`The requirement for the veteran feedback role has been set to ${newRequirement} points.`);
     }
     else {
-        messageEmbed.setDescription(`The requirement for the regular feedback role has been set to ${newRequirement}.`);
+        messageEmbed.setDescription(`The requirement for the regular feedback role has been set to ${newRequirement} points.`);
     }
     
     messageEmbed.setColor(Colors.Green);

--- a/commands/moderation/adminCommands.js
+++ b/commands/moderation/adminCommands.js
@@ -15,55 +15,60 @@ const SET_ROLE_COMMAND_NAME = "setrole";
 
 const EPHEMERAL_FLAG = MessageFlags.Ephemeral
 
-// Handles the '/admin setchannel' command.
-// interaction: the interaction that used this command
-// messageEmbed: the embed to modify and reply with
-// returns false if the action failed.
-async function handleSetChannel(interaction, messageEmbed) {
-    const feedbackChannel = interaction.options.getChannel(CHANNEL_OPTION_NAME);
+const COMMAND_FUNCTIONS = {
     
-    messageEmbed.setDescription(`${feedbackChannel} has been set as the feedback forum channel.`);
-    messageEmbed.setColor(Colors.Green);
-    return true;
-}
-
-// Handles the '/admin setrequirement' command.
-// interaction: the interaction that used this command
-// messageEmbed: the embed to modify and reply with
-// returns false if the action failed.
-async function handleSetRequirement(interaction, messageEmbed) {
-    const settingVeteranReq = interaction.options.getBoolean(SET_VETERAN_OPTION_NAME);
-    const newRequirement = interaction.options.getInteger(REQUIREMENT_OPTION_NAME);
+    // Handles the '/admin setchannel' command.
+    // interaction: the interaction that used this command
+    // messageEmbed: the embed to modify and reply with
+    // returns false if the action failed.
+    [SET_CHANNEL_COMMAND_NAME]: function handleSetChannel(interaction, messageEmbed) {
+        const feedbackChannel = interaction.options.getChannel(CHANNEL_OPTION_NAME);
+        
+        messageEmbed.setDescription(`${feedbackChannel} has been set as the feedback forum channel.`);
+        messageEmbed.setColor(Colors.Green);
+        return true;
+    },
     
-    if (settingVeteranReq) {
-        messageEmbed.setDescription(`The requirement for the veteran feedback role has been set to ${newRequirement} points.`);
+    // Handles the '/admin setrequirement' command.
+    // interaction: the interaction that used this command
+    // messageEmbed: the embed to modify and reply with
+    // returns false if the action failed.
+    [SET_REQUIREMENT_COMMAND_NAME]: function handleSetRequirement(interaction, messageEmbed) {
+        const settingVeteranReq = interaction.options.getBoolean(SET_VETERAN_OPTION_NAME);
+        const newRequirement = interaction.options.getInteger(REQUIREMENT_OPTION_NAME);
+        
+        if (settingVeteranReq) {
+            // points doesn't singularize with the argument as 1, but this is such a small and unlikely scenario so i won't fix
+            messageEmbed.setDescription(`The requirement for the veteran feedback role has been set to ${newRequirement} points.`);
+        }
+        else {
+            messageEmbed.setDescription(`The requirement for the regular feedback role has been set to ${newRequirement} points.`);
+        }
+        
+        messageEmbed.setColor(Colors.Green);
+        return true;
+    },
+    
+    // Handles the '/admin setrole' command.
+    // interaction: the interaction that used this command
+    // messageEmbed: the embed to modify and reply with
+    // returns false if the action failed.
+    [SET_ROLE_COMMAND_NAME]: function handleSetRole(interaction, messageEmbed) {
+        const settingVeteranReq = interaction.options.getBoolean(SET_VETERAN_ROLE_OPTION_NAME);
+        const newRole = interaction.options.getRole(ROLE_OPTION_NAME);
+        
+        if (settingVeteranReq) {
+            messageEmbed.setDescription(`The veteran feedbacker role has been set to ${newRole}.`);
+        }
+        else {
+            messageEmbed.setDescription(`The regular feedbacker role has been set to ${newRole}.`);
+        }
+        
+        messageEmbed.setColor(Colors.Green);
+        return true;
     }
-    else {
-        messageEmbed.setDescription(`The requirement for the regular feedback role has been set to ${newRequirement} points.`);
-    }
     
-    messageEmbed.setColor(Colors.Green);
-    return true;
-}
-
-// Handles the '/admin setrole' command.
-// interaction: the interaction that used this command
-// messageEmbed: the embed to modify and reply with
-// returns false if the action failed.
-async function handleSetRole(interaction, messageEmbed) {
-    const settingVeteranReq = interaction.options.getBoolean(SET_VETERAN_ROLE_OPTION_NAME);
-    const newRole = interaction.options.getRole(ROLE_OPTION_NAME);
-    
-    if (settingVeteranReq) {
-        messageEmbed.setDescription(`The veteran feedbacker role has been set to ${newRole}.`);
-    }
-    else {
-        messageEmbed.setDescription(`The regular feedbacker role has been set to ${newRole}.`);
-    }
-    
-    messageEmbed.setColor(Colors.Green);
-    return true;
-}
+};
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -115,21 +120,13 @@ module.exports = {
 
     async execute(interaction) {
 
+        const subcommandName = interaction.options.getSubcommand();
         let newEmbed = new EmbedBuilder().setTimestamp().setDescription("This command has not been fully implemented.");
         let successful = false;
-
-        // action based on subcommand
-        switch (interaction.options.getSubcommand()) {
-            case (SET_CHANNEL_COMMAND_NAME):
-                successful = handleSetChannel(interaction, newEmbed);
-                break;
-            case (SET_REQUIREMENT_COMMAND_NAME):
-                successful = handleSetRequirement(interaction, newEmbed);
-                break;
-            case (SET_ROLE_COMMAND_NAME):
-                successful = handleSetRole(interaction, newEmbed);
-            default:
-                break;
+        
+        // call the function if the subcommand name is a key in the function hash map
+        if (subcommandName in COMMAND_FUNCTIONS) {
+            successful = COMMAND_FUNCTIONS[subcommandName](interaction, newEmbed);
         }
         
         if (successful) {

--- a/commands/moderation/adminCommands.js
+++ b/commands/moderation/adminCommands.js
@@ -1,14 +1,17 @@
 const { SlashCommandBuilder, SlashCommandSubcommandBuilder, SlashCommandChannelOption, SlashCommandIntegerOption, 
-    SlashCommandBooleanOption, PermissionFlagsBits, EmbedBuilder, Colors, MessageFlags, ChannelType }
+    SlashCommandBooleanOption, SlashCommandRoleOption, PermissionFlagsBits, EmbedBuilder, Colors, MessageFlags, ChannelType }
     = require("discord.js");
 
 // Constants
 const CHANNEL_OPTION_NAME = "feedbackchannel";
-const REQUIREMENT_OPTION_NAME = "newrequirement";
+const REQUIREMENT_OPTION_NAME = "requirement";
+const ROLE_OPTION_NAME = "role";
 const SET_VETERAN_OPTION_NAME = "setveteranrequirement";
+const SET_VETERAN_ROLE_OPTION_NAME = "setveteranrole";
 
 const SET_CHANNEL_COMMAND_NAME = "setchannel";
 const SET_REQUIREMENT_COMMAND_NAME = "setrequirement";
+const SET_ROLE_COMMAND_NAME = "setrole";
 
 const EPHEMERAL_FLAG = MessageFlags.Ephemeral
 
@@ -37,6 +40,25 @@ async function handleSetRequirement(interaction, messageEmbed) {
     }
     else {
         messageEmbed.setDescription(`The requirement for the regular feedback role has been set to ${newRequirement} points.`);
+    }
+    
+    messageEmbed.setColor(Colors.Green);
+    return true;
+}
+
+// Handles the '/admin setrole' command.
+// interaction: the interaction that used this command
+// messageEmbed: the embed to modify and reply with
+// returns false if the action failed.
+async function handleSetRole(interaction, messageEmbed) {
+    const settingVeteranReq = interaction.options.getBoolean(SET_VETERAN_ROLE_OPTION_NAME);
+    const newRole = interaction.options.getRole(ROLE_OPTION_NAME);
+    
+    if (settingVeteranReq) {
+        messageEmbed.setDescription(`The veteran feedbacker role has been set to ${newRole}.`);
+    }
+    else {
+        messageEmbed.setDescription(`The regular feedbacker role has been set to ${newRole}.`);
     }
     
     messageEmbed.setColor(Colors.Green);
@@ -74,11 +96,26 @@ module.exports = {
                 .setRequired(true)
                 .setMinValue(1)
             )
+        )
+        
+        .addSubcommand(new SlashCommandSubcommandBuilder()
+            .setName(SET_ROLE_COMMAND_NAME)
+            .setDescription("Sets the role that is obtained for reaching specific feedback point requirements.")
+            .addBooleanOption(new SlashCommandBooleanOption()
+                .setName(SET_VETERAN_ROLE_OPTION_NAME)
+                .setDescription("If true, the veteran role will be set. Sets the regular role otherwise.")
+                .setRequired(true)
+            )
+            .addRoleOption(new SlashCommandRoleOption()
+                .setName(ROLE_OPTION_NAME)
+                .setDescription("The role to use for the point requirement.")
+                .setRequired(true)
+            )
         ),
 
     async execute(interaction) {
 
-        let newEmbed = new EmbedBuilder().setTimestamp();
+        let newEmbed = new EmbedBuilder().setTimestamp().setDescription("This command has not been fully implemented.");
         let successful = false;
 
         // action based on subcommand
@@ -88,6 +125,9 @@ module.exports = {
                 break;
             case (SET_REQUIREMENT_COMMAND_NAME):
                 successful = handleSetRequirement(interaction, newEmbed);
+                break;
+            case (SET_ROLE_COMMAND_NAME):
+                successful = handleSetRole(interaction, newEmbed);
             default:
                 break;
         }

--- a/commands/moderation/adminCommands.js
+++ b/commands/moderation/adminCommands.js
@@ -1,0 +1,102 @@
+const { SlashCommandBuilder, SlashCommandSubcommandBuilder, SlashCommandChannelOption, SlashCommandIntegerOption, 
+    SlashCommandBooleanOption, PermissionFlagsBits, EmbedBuilder, Colors, MessageFlags, ChannelType }
+    = require("discord.js");
+
+// Constants
+const CHANNEL_OPTION_NAME = "feedbackchannel";
+const REQUIREMENT_OPTION_NAME = "newrequirement";
+const SET_VETERAN_OPTION_NAME = "setveteranrequirement";
+
+const SET_CHANNEL_COMMAND_NAME = "setchannel";
+const SET_REQUIREMENT_COMMAND_NAME = "setrequirement";
+
+const EPHEMERAL_FLAG = MessageFlags.Ephemeral
+
+// Handles the '/admin setchannel' command.
+// interaction: the interaction that used this command
+// messageEmbed: the embed to modify and reply with
+// returns false if the action failed.
+async function handleSetChannel(interaction, messageEmbed) {
+    const feedbackChannel = interaction.options.getChannel(CHANNEL_OPTION_NAME);
+    
+    messageEmbed.setDescription(`${feedbackChannel} has been set as the feedback forum channel.`);
+    messageEmbed.setColor(Colors.Green);
+    return true;
+}
+
+// Handles the '/admin setrequirement' command.
+// interaction: the interaction that used this command
+// messageEmbed: the embed to modify and reply with
+// returns false if the action failed.
+async function handleSetRequirement(interaction, messageEmbed) {
+    const settingVeteranReq = interaction.options.getBoolean(SET_VETERAN_OPTION_NAME);
+    const newRequirement = interaction.options.getInteger(REQUIREMENT_OPTION_NAME);
+    
+    if (settingVeteranReq) {
+        messageEmbed.setDescription(`The requirement for the veteran feedback role has been set to ${newRequirement}.`);
+    }
+    else {
+        messageEmbed.setDescription(`The requirement for the regular feedback role has been set to ${newRequirement}.`);
+    }
+    
+    messageEmbed.setColor(Colors.Green);
+    return true;
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("admin")
+        .setDescription("administrator commands")
+        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+        
+        .addSubcommand(new SlashCommandSubcommandBuilder()
+            .setName(SET_CHANNEL_COMMAND_NAME)
+            .setDescription("Sets a forum channel as the feedback channel, allowing feedback contracts to be posted.")
+            .addChannelOption(new SlashCommandChannelOption()
+                .setName(CHANNEL_OPTION_NAME)
+                .setDescription("The channel to set as the feedback channel")
+                .setRequired(true)
+                .addChannelTypes(ChannelType.GuildForum)
+            )
+        )
+
+        .addSubcommand(new SlashCommandSubcommandBuilder()
+            .setName(SET_REQUIREMENT_COMMAND_NAME)
+            .setDescription("Sets the feedback point requirement to obtain a specific role.")
+            .addBooleanOption(new SlashCommandBooleanOption()
+                .setName(SET_VETERAN_OPTION_NAME)
+                .setDescription("If true, the veteran requirement will be set. Sets the regular requirement otherwise.") // constrained to 100 chars, can't have proper wording
+                .setRequired(true)
+            )
+            .addIntegerOption(new SlashCommandIntegerOption()
+                .setName(REQUIREMENT_OPTION_NAME)
+                .setDescription("The new requirement for the role")
+                .setRequired(true)
+                .setMinValue(1)
+            )
+        ),
+
+    async execute(interaction) {
+
+        let newEmbed = new EmbedBuilder().setTimestamp();
+        let successful = false;
+
+        // action based on subcommand
+        switch (interaction.options.getSubcommand()) {
+            case (SET_CHANNEL_COMMAND_NAME):
+                successful = handleSetChannel(interaction, newEmbed);
+                break;
+            case (SET_REQUIREMENT_COMMAND_NAME):
+                successful = handleSetRequirement(interaction, newEmbed);
+            default:
+                break;
+        }
+        
+        if (successful) {
+            await interaction.reply({embeds: [newEmbed]});
+        }
+        else {
+            await interaction.reply({embeds: [newEmbed], flags: EPHEMERAL_FLAG});
+        }
+    },
+};

--- a/commands/moderation/modCommands.js
+++ b/commands/moderation/modCommands.js
@@ -14,46 +14,50 @@ const UNBLOCK_COMMAND_NAME = "unblock";
 
 const EPHEMERAL_FLAG = MessageFlags.Ephemeral
 
-// Handles the '/mod block' command.
-// interaction: the interaction that used this command
-// messageEmbed: the embed to modify and reply with
-// returns false if the action failed.
-async function handleBlock(interaction, messageEmbed) {
-    const blockee = interaction.options.getUser(USER_OPTION_NAME);
-    
-    // TODO: check if the blockee is already blocked, if so then notify the command user.
-    
-    messageEmbed.setDescription(`${blockee} has been blocked from creating feedback contracts.`);
-    messageEmbed.setColor(Colors.Red);
-    return true;
-}
+const COMMAND_FUNCTIONS = {
+  
+    // Handles the '/mod block' command.
+    // interaction: the interaction that used this command
+    // messageEmbed: the embed to modify and reply with
+    // returns false if the action failed.
+    [BLOCK_COMMAND_NAME]: function handleBlock(interaction, messageEmbed) {
+        const blockee = interaction.options.getUser(USER_OPTION_NAME);
+        
+        // TODO: check if the blockee is already blocked, if so then notify the command user.
+        
+        messageEmbed.setDescription(`${blockee} has been blocked from creating feedback contracts.`);
+        messageEmbed.setColor(Colors.Red);
+        return true;
+    },
 
-// Handles the '/mod unblock' command.
-// interaction: the interaction that used this command
-// messageEmbed: the embed to modify and reply with
-// returns false if the action failed.
-async function handleUnblock(interaction, messageEmbed) {
-    const unblockee = interaction.options.getUser(USER_OPTION_NAME);
-    
-    // TODO: check if the unblockee is not blocked, if so then notify the command user.
-    
-    messageEmbed.setDescription(`${unblockee} has been unblocked and can now create feedback contracts.`);
-    messageEmbed.setColor(Colors.Green);
-    return true;
-}
+    // Handles the '/mod unblock' command.
+    // interaction: the interaction that used this command
+    // messageEmbed: the embed to modify and reply with
+    // returns false if the action failed.
+    [UNBLOCK_COMMAND_NAME]: function handleUnblock(interaction, messageEmbed) {
+        const unblockee = interaction.options.getUser(USER_OPTION_NAME);
+        
+        // TODO: check if the unblockee is not blocked, if so then notify the command user.
+        
+        messageEmbed.setDescription(`${unblockee} has been unblocked and can now create feedback contracts.`);
+        messageEmbed.setColor(Colors.Green);
+        return true;
+    },
 
-// Handles the '/mod setpoints' command.
-// interaction: the interaction that used this command
-// messageEmbed: the embed to modify and reply with
-// returns false if the action failed.
-async function handleSetPoints(interaction, messageEmbed) {
-    const user = interaction.options.getUser(USER_OPTION_NAME);
-    const points = interaction.options.getInteger(POINTS_OPTION_NAME);
-    userMethods.setPoints(user.id, points);
-    messageEmbed.setDescription(`${user} now has ${points} points.`);
-    messageEmbed.setColor(Colors.Green);
-    return true;
-}
+    // Handles the '/mod setpoints' command.
+    // interaction: the interaction that used this command
+    // messageEmbed: the embed to modify and reply with
+    // returns false if the action failed.
+    [SET_POINTS_COMMAND_NAME]: function handleSetPoints(interaction, messageEmbed) {
+        const user = interaction.options.getUser(USER_OPTION_NAME);
+        const points = interaction.options.getInteger(POINTS_OPTION_NAME);
+        userMethods.setPoints(user.id, points);
+        messageEmbed.setDescription(`${user} now has ${points} points.`);
+        messageEmbed.setColor(Colors.Green);
+        return true;
+    }
+  
+};
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -99,21 +103,13 @@ module.exports = {
 
     async execute(interaction) {
 
+        const subcommandName = interaction.options.getSubcommand();
         let newEmbed = new EmbedBuilder().setTimestamp().setDescription("This command has not been fully implemented.");
         let successful = false;
 
-        // action based on subcommand
-        switch (interaction.options.getSubcommand()) {
-            case (BLOCK_COMMAND_NAME):
-                successful = handleBlock(interaction, newEmbed);
-                break;
-            case (UNBLOCK_COMMAND_NAME):
-                successful = handleUnblock(interaction, newEmbed);
-                break;
-            case (SET_POINTS_COMMAND_NAME):
-                successful = handleSetPoints(interaction, newEmbed);
-            default:
-                break;
+        // call the function if the subcommand name is a key in the function hash map
+        if (subcommandName in COMMAND_FUNCTIONS) {
+            successful = COMMAND_FUNCTIONS[subcommandName](interaction, newEmbed);
         }
         
         if (successful) {

--- a/commands/moderation/modCommands.js
+++ b/commands/moderation/modCommands.js
@@ -99,7 +99,7 @@ module.exports = {
 
     async execute(interaction) {
 
-        let newEmbed = new EmbedBuilder().setTimestamp();
+        let newEmbed = new EmbedBuilder().setTimestamp().setDescription("This command has not been fully implemented.");
         let successful = false;
 
         // action based on subcommand

--- a/commands/moderation/modCommands.js
+++ b/commands/moderation/modCommands.js
@@ -1,12 +1,10 @@
 const { SlashCommandBuilder, SlashCommandSubcommandBuilder, SlashCommandUserOption, SlashCommandIntegerOption, 
-    PermissionsBitField, EmbedBuilder, Colors, MessageFlags }
+    PermissionFlagsBits, EmbedBuilder, Colors, MessageFlags }
     = require("discord.js");
 
 const userMethods = require("../../helpers/userMethods.js")
 
 // Constants
-const MOD_PERMS = [PermissionsBitField.Flags.Administrator, PermissionsBitField.Flags.BanMembers]; // 8 (admin) or 4 (ban members)
-
 const USER_OPTION_NAME = "user";
 const POINTS_OPTION_NAME = "points";
 
@@ -21,7 +19,7 @@ const EPHEMERAL_FLAG = MessageFlags.Ephemeral
 // messageEmbed: the embed to modify and reply with
 // returns false if the action failed.
 async function handleBlock(interaction, messageEmbed) {
-    let blockee = interaction.options.getUser(USER_OPTION_NAME);
+    const blockee = interaction.options.getUser(USER_OPTION_NAME);
     
     // TODO: check if the blockee is already blocked, if so then notify the command user.
     
@@ -35,7 +33,7 @@ async function handleBlock(interaction, messageEmbed) {
 // messageEmbed: the embed to modify and reply with
 // returns false if the action failed.
 async function handleUnblock(interaction, messageEmbed) {
-    let unblockee = interaction.options.getUser(USER_OPTION_NAME);
+    const unblockee = interaction.options.getUser(USER_OPTION_NAME);
     
     // TODO: check if the unblockee is not blocked, if so then notify the command user.
     
@@ -61,6 +59,7 @@ module.exports = {
     data: new SlashCommandBuilder()
         .setName("mod")
         .setDescription("Moderator commands")
+        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
         
         .addSubcommand(new SlashCommandSubcommandBuilder()
             .setName(BLOCK_COMMAND_NAME)
@@ -99,12 +98,6 @@ module.exports = {
         ),
 
     async execute(interaction) {
-        // check that the user has moderator permissions
-        if (!interaction.member.permissions.any(MOD_PERMS)) {
-            // non moderator error
-            await interaction.reply({content: "You need moderator permissions to run this command.", flags: EPHEMERAL_FLAG});
-            return;
-        }
 
         let newEmbed = new EmbedBuilder().setTimestamp();
         let successful = false;


### PR DESCRIPTION
This PR adds `/admin setchannel` (set the feedback channel), `/admin setrole` (set the role for point milestones) and `/admin setrequirement` (set point requirement for roles). These commands are only visual, and setting storage has yet to be implemented.

Additionally, this PR changes the mod commands to use a built in permission setting (which these new admin commands have), making them not appear to non moderators/admins.

Closes #15 