### PR TITLE
Add feedback thread ownership detection

### DIFF
--- a/commands/contractCommands.js
+++ b/commands/contractCommands.js
@@ -4,6 +4,7 @@ const { createContractMessage } = require("../handlers/contract");
 const { subcommandExecute } = require("../handlers/commands.js")
 const contractMethods = require("../helpers/contractMethods.js");
 const userMethods = require("../helpers/userMethods.js");
+const { getFeedbackChannelId } = require("../helpers/settingsMethods.js");
 
 // Constants
 const CREATE_COMMAND_NAME = "create";
@@ -23,10 +24,13 @@ const COMMAND_FUNCTIONS = {
         // Check if the interaction occurred within a feedback thread
         const feedbackThread = await contractMethods.getFeedbackThreadFromInteraction(interaction);
         if (!feedbackThread) {
+            // Get the actual feedback thread ID to include in the error message
+            const realFeedbackThread = await getFeedbackChannelId();
+
             const responseEmbed = new EmbedBuilder()
                 .setTimestamp()
                 .setColor(Colors.Red)
-                .setDescription(`You can only use ${inlineCode(`/contract ${CREATE_COMMAND_NAME}`)} within feedback threads.`);
+                .setDescription(`You can only use ${inlineCode(`/contract ${CREATE_COMMAND_NAME}`)} within <#${realFeedbackThread}>.`);
             
             await interaction.reply({embeds: [responseEmbed], flags: MessageFlags.Ephemeral});
             return false;
@@ -59,10 +63,13 @@ const COMMAND_FUNCTIONS = {
         // Check if the interaction occurred within a feedback thread
         const feedbackThread = await contractMethods.getFeedbackThreadFromInteraction(interaction);
         if (!feedbackThread) {
+            // Get the actual feedback thread ID to include in the error message
+            const realFeedbackThread = await getFeedbackChannelId();
+            
             const responseEmbed = new EmbedBuilder()
                 .setTimestamp()
                 .setColor(Colors.Red)
-                .setDescription(`You can only use ${inlineCode(`/contract ${GET_INFO_COMMAND_NAME}`)} within feedback threads.`);
+                .setDescription(`You can only use ${inlineCode(`/contract ${GET_INFO_COMMAND_NAME}`)} within <#${realFeedbackThread}>.`);
             
             await interaction.reply({embeds: [responseEmbed], flags: MessageFlags.Ephemeral});
             return false;

--- a/commands/contractCommands.js
+++ b/commands/contractCommands.js
@@ -19,7 +19,7 @@ const COMMAND_FUNCTIONS = {
      * @return {boolean} true if the command succeeded, false if it failed.
      */
     [CREATE_COMMAND_NAME]: async function handleContractCreate(interaction) {
-        const ping_thread_owner = interaction.options.getBoolean(PING_OPTION_NAME);
+        const pingThreadOwner = interaction.options.getBoolean(PING_OPTION_NAME);
 
         // Check if the interaction occurred within a feedback thread
         const feedbackThread = await contractMethods.getFeedbackThreadFromInteraction(interaction);
@@ -48,8 +48,8 @@ const COMMAND_FUNCTIONS = {
         else {
             // Component creation has been outsourced to handlers </3
             // Pings the thread owner if that option is set to true
-            const ping_id = ping_thread_owner ? await contractMethods.getFeedbackThreadOwnerId(feedbackThread) : null;
-            await interaction.reply(createContractMessage(interaction, ping_id));
+            const pingId = pingThreadOwner ? await contractMethods.getFeedbackThreadOwnerId(feedbackThread) : null;
+            await interaction.reply(createContractMessage(interaction, pingId));
             return true;
         }
     },
@@ -65,7 +65,7 @@ const COMMAND_FUNCTIONS = {
         if (!feedbackThread) {
             // Get the actual feedback thread ID to include in the error message
             const realFeedbackThread = await getFeedbackChannelId();
-            
+
             const responseEmbed = new EmbedBuilder()
                 .setTimestamp()
                 .setColor(Colors.Red)
@@ -75,12 +75,12 @@ const COMMAND_FUNCTIONS = {
             return false;
         }
         else {
-            const feedback_thread_owner_id = await contractMethods.getFeedbackThreadOwnerId(feedbackThread);
+            const feedbackThreadOwnerId = await contractMethods.getFeedbackThreadOwnerId(feedbackThread);
 
             const responseEmbed = new EmbedBuilder()
                 .setTimestamp()
                 .setColor(Colors.Blue)
-                .setDescription(`Builder: <@${feedback_thread_owner_id}>`);
+                .setDescription(`Builder: <@${feedbackThreadOwnerId}>`);
 
             await interaction.reply({embeds: [responseEmbed]});
             return true;

--- a/commands/contractCommands.js
+++ b/commands/contractCommands.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, SlashCommandSubcommandBuilder, EmbedBuilder, Colors
 
 const { createContractMessage } = require("../handlers/contract");
 const { subcommandExecute } = require("../handlers/commands.js")
+const contractMethods = require("../helpers/contractMethods.js");
 const userMethods = require("../helpers/userMethods.js");
 
 // Constants
@@ -14,8 +15,18 @@ const COMMAND_FUNCTIONS = {
      */
     [CREATE_COMMAND_NAME]: async function handleContractCreate(interaction) {
         
-        // check the user is blocked... this function is empty no longer
-        if (userMethods.getIsBlocked(interaction.user.id)) {
+        // Check if the interaction occurred within a feedback thread
+        const feedbackThread = await contractMethods.getFeedbackThreadFromInteraction(interaction);
+        if (!feedbackThread) {
+            let responseEmbed = new EmbedBuilder()
+                .setTimestamp()
+                .setColor(Colors.Red)
+                .setDescription(`You can only use ${`/contract ${CREATE_COMMAND_NAME}`} within feedback threads.`);
+            
+            await interaction.reply({embeds: [responseEmbed], flags: MessageFlags.Ephemeral});
+        }
+        // Check if the user is blocked
+        else if (userMethods.getIsBlocked(interaction.user.id)) {
             let responseEmbed = new EmbedBuilder()
                 .setTimestamp()
                 .setColor(Colors.Red)

--- a/commands/contractCommands.js
+++ b/commands/contractCommands.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, SlashCommandSubcommandBuilder, EmbedBuilder, Colors, MessageFlags } = require("discord.js");
+const { SlashCommandBuilder, SlashCommandSubcommandBuilder, EmbedBuilder, Colors, MessageFlags, CommandInteractionOptionResolver, inlineCode } = require("discord.js");
 
 const { createContractMessage } = require("../handlers/contract");
 const { subcommandExecute } = require("../handlers/commands.js")
@@ -6,7 +6,8 @@ const contractMethods = require("../helpers/contractMethods.js");
 const userMethods = require("../helpers/userMethods.js");
 
 // Constants
-const CREATE_COMMAND_NAME = "create"
+const CREATE_COMMAND_NAME = "create";
+const GET_INFO_COMMAND_NAME = "getinfo";
 
 const COMMAND_FUNCTIONS = {
     /**
@@ -14,20 +15,19 @@ const COMMAND_FUNCTIONS = {
      * @param {CommandInteractionOptionResolver} interaction The interaction that used this command.
      */
     [CREATE_COMMAND_NAME]: async function handleContractCreate(interaction) {
-        
         // Check if the interaction occurred within a feedback thread
         const feedbackThread = await contractMethods.getFeedbackThreadFromInteraction(interaction);
         if (!feedbackThread) {
-            let responseEmbed = new EmbedBuilder()
+            const responseEmbed = new EmbedBuilder()
                 .setTimestamp()
                 .setColor(Colors.Red)
-                .setDescription(`You can only use ${`/contract ${CREATE_COMMAND_NAME}`} within feedback threads.`);
+                .setDescription(`You can only use ${inlineCode(`/contract ${CREATE_COMMAND_NAME}`)} within feedback threads.`);
             
             await interaction.reply({embeds: [responseEmbed], flags: MessageFlags.Ephemeral});
         }
         // Check if the user is blocked
         else if (userMethods.getIsBlocked(interaction.user.id)) {
-            let responseEmbed = new EmbedBuilder()
+            const responseEmbed = new EmbedBuilder()
                 .setTimestamp()
                 .setColor(Colors.Red)
                 .setDescription("You have been blocked from creating feedback contracts for spam or abuse.");
@@ -38,7 +38,34 @@ const COMMAND_FUNCTIONS = {
             // Component creation has been outsourced to handlers </3
             await interaction.reply(createContractMessage(interaction));
         }
-    }
+    },
+
+    /**
+     * Handles the `/contract getinfo` subcommand.
+     * @param {CommandInteractionOptionResolver} interaction The interaction that used this command.
+     */
+    [GET_INFO_COMMAND_NAME]: async function handleContractGetInfo(interaction) {
+        // Check if the interaction occurred within a feedback thread
+        const feedbackThread = await contractMethods.getFeedbackThreadFromInteraction(interaction);
+        if (!feedbackThread) {
+            const responseEmbed = new EmbedBuilder()
+                .setTimestamp()
+                .setColor(Colors.Red)
+                .setDescription(`You can only use ${inlineCode(`/contract ${GET_INFO_COMMAND_NAME}`)} within feedback threads.`);
+            
+            await interaction.reply({embeds: [responseEmbed], flags: MessageFlags.Ephemeral});
+        }
+        else {
+            const feedback_thread_owner_id = await contractMethods.getFeedbackThreadOwnerId(feedbackThread);
+
+            const responseEmbed = new EmbedBuilder()
+                .setTimestamp()
+                .setColor(Colors.Blue)
+                .setDescription(`Builder: <@${feedback_thread_owner_id}>`);
+
+            await interaction.reply({embeds: [responseEmbed]});
+        }
+    },
 };
 
 module.exports = {
@@ -49,6 +76,11 @@ module.exports = {
         .addSubcommand(new SlashCommandSubcommandBuilder()
             .setName(CREATE_COMMAND_NAME)
             .setDescription("Creates a feedback contract")
+        )
+
+        .addSubcommand(new SlashCommandSubcommandBuilder()
+            .setName(GET_INFO_COMMAND_NAME)
+            .setDescription("Displays info about the current feedback thread")
         ),
 
     async execute(interaction) {

--- a/handlers/contract.js
+++ b/handlers/contract.js
@@ -157,10 +157,10 @@ function createContractMessage(interaction, pingId) {
     // Adds a thread owner ping to the message
     const threadOwnerPing = pingId ? `<@${pingId}>` : null;
     // Preserves the thread owner ping between message updates
-    const previous_content = interaction.message ? interaction.message.content : null;
+    const previousContent = interaction.message ? interaction.message.content : null;
 
     return {
-        content: threadOwnerPing || previous_content,
+        content: threadOwnerPing || previousContent,
         embeds: [newContractEmbed],
         components: [row1, row2],
     };

--- a/handlers/contract.js
+++ b/handlers/contract.js
@@ -1,4 +1,4 @@
-const { ButtonBuilder, ButtonStyle, ActionRowBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, EmbedBuilder, Colors, bold, CommandInteractionOptionResolver, strikethrough, blockQuote, underline, subtext } = require("discord.js");
+const { ButtonBuilder, ButtonStyle, ActionRowBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, EmbedBuilder, Colors, bold, strikethrough, blockQuote, underline, subtext } = require("discord.js");
 
 const HORIZONTAL_RULE = `\n${subtext(strikethrough("-------------------------------"))}\n`;
 const STAR_RATING_INFO = {
@@ -133,9 +133,10 @@ function createContractEmbed(interaction, star_rating) {
 /**
  * Constructs a complete contract message, including an embed, rating select, and confirm button.
  * @param {import("discord.js").Interaction} interaction The interaction that created/used the contract.
+ * @param {string?} ping_id ID of the user to ping within the contract message.
  * @returns {import("discord.js").InteractionReplyOptions} The created contract message.
  */
-function createContractMessage(interaction) {
+function createContractMessage(interaction, ping_id) {
 
     // If no star rating is selected, this is just null
     const selectedStarRating = interaction.values ? interaction.values[0] : null;
@@ -152,8 +153,14 @@ function createContractMessage(interaction) {
     
     const row2 = new ActionRowBuilder()
         .addComponents(newConfirmButton);
+    
+    // Adds a thread owner ping to the message
+    const thread_owner_ping = ping_id ? `<@${ping_id}>` : null;
+    // Preserves the thread owner ping between message updates
+    const previous_content = interaction.message ? interaction.message.content : null;
 
     return {
+        content: thread_owner_ping || previous_content,
         embeds: [newContractEmbed],
         components: [row1, row2],
     };

--- a/handlers/contract.js
+++ b/handlers/contract.js
@@ -74,58 +74,58 @@ function createConfirmButton(disabled = true) {
 
 /**
  * Creates a new embed corresponding to the selected star rating.
- * @param {String?} star_rating The selected star rating as a string.
+ * @param {String?} starRating The selected star rating as a string.
  * @param {import("discord.js").Interaction} interaction The interaction that used this command.
  * @returns {EmbedBuilder} An embed corresponding to the selected star rating.
  */
-function createContractEmbed(interaction, star_rating) {
+function createContractEmbed(interaction, starRating) {
 
     // Get star rating info from star rating
-    const star_data = STAR_RATING_INFO[star_rating];
+    const starData = STAR_RATING_INFO[starRating];
 
     // Assign description and star rating label
-    let full_description = null;
-    let star_rating_label = "";
-    if (star_rating) {
-        full_description = star_data.full_description;
-        point_value = star_data.point_value
-        star_rating_label = `${star_data.menu_label} ${point_value} STAR${point_value === 1 ? '' : 'S'}`;
+    let fullDescription = null;
+    let starRatingLabel = "";
+    if (starRating) {
+        fullDescription = starData.full_description;
+        pointValue = starData.point_value
+        starRatingLabel = `${starData.menu_label} ${pointValue} STAR${pointValue === 1 ? '' : 'S'}`;
     }
 
     // Get the user (as an author) who sent the contract originally
     // This may seem weird, but I swear it's like this for a reason
-    const contract_sender_author = {
+    const contractSenderAuthor = {
         name: interaction.user.username, 
         iconURL: interaction.user.avatarURL(),
     };
-    let contract_sender_userid = interaction.user.id;
+    let contractSenderUserId = interaction.user.id;
     if (interaction.message) {
         // Drill, baby, drill!
-        const embed_data = interaction.message.embeds[0].data;
-        const author_data = embed_data.author;
-        contract_sender_author.name = author_data.name;
-        contract_sender_author.iconURL = author_data.icon_url;
+        const embedData = interaction.message.embeds[0].data;
+        const authorData = embedData.author;
+        contractSenderAuthor.name = authorData.name;
+        contractSenderAuthor.iconURL = authorData.icon_url;
 
         // Extract the contract sender's user ID from the description in the embed (THIS IS SO BAD)
-        const embed_description = embed_data.description;
+        const embedDescription = embedData.description;
         // ^^^^^^ Example of the string we're dissecting: 
         // '<@699811922283629313> has completed their feedback! Please use the dropdown menu to rate their feedback's quality, and click "Confirm" to submit.'
-        const idx_a = embed_description.indexOf('@');
-        const idx_b = embed_description.indexOf('>');
-        contract_sender_userid = embed_description.slice(idx_a + 1, idx_b);
+        const idxA = embedDescription.indexOf('@');
+        const idxB = embedDescription.indexOf('>');
+        contractSenderUserId = embedDescription.slice(idxA + 1, idxB);
     }
 
     // Build the embed
     const embed = new EmbedBuilder()
         .setColor(Colors.Green)
         .setTitle("Feedback Agreement")
-        .setAuthor(contract_sender_author)
+        .setAuthor(contractSenderAuthor)
         .setDescription(
-            `<@${contract_sender_userid}> has completed their feedback! Please use the dropdown menu to rate their feedback's quality, and click "Confirm" to submit.
-            ${full_description ? `${HORIZONTAL_RULE}# ` + star_rating_label + "\n" + blockQuote(full_description) : ""}`)
+            `<@${contractSenderUserId}> has completed their feedback! Please use the dropdown menu to rate their feedback's quality, and click "Confirm" to submit.
+            ${fullDescription ? `${HORIZONTAL_RULE}# ` + starRatingLabel + "\n" + blockQuote(fullDescription) : ""}`)
         .setTimestamp();
     // Save original author to embed's data so it can be reused later
-    embed.original_author = contract_sender_author;
+    embed.original_author = contractSenderAuthor;
     
     return embed;
 }
@@ -133,10 +133,10 @@ function createContractEmbed(interaction, star_rating) {
 /**
  * Constructs a complete contract message, including an embed, rating select, and confirm button.
  * @param {import("discord.js").Interaction} interaction The interaction that created/used the contract.
- * @param {string?} ping_id ID of the user to ping within the contract message.
+ * @param {string?} pingId ID of the user to ping within the contract message.
  * @returns {import("discord.js").InteractionReplyOptions} The created contract message.
  */
-function createContractMessage(interaction, ping_id) {
+function createContractMessage(interaction, pingId) {
 
     // If no star rating is selected, this is just null
     const selectedStarRating = interaction.values ? interaction.values[0] : null;
@@ -155,12 +155,12 @@ function createContractMessage(interaction, ping_id) {
         .addComponents(newConfirmButton);
     
     // Adds a thread owner ping to the message
-    const thread_owner_ping = ping_id ? `<@${ping_id}>` : null;
+    const threadOwnerPing = pingId ? `<@${pingId}>` : null;
     // Preserves the thread owner ping between message updates
     const previous_content = interaction.message ? interaction.message.content : null;
 
     return {
-        content: thread_owner_ping || previous_content,
+        content: threadOwnerPing || previous_content,
         embeds: [newContractEmbed],
         components: [row1, row2],
     };

--- a/helpers/contractMethods.js
+++ b/helpers/contractMethods.js
@@ -9,7 +9,8 @@ const { getFeedbackChannelId } = require('./settingsMethods');
  * @returns {ThreadChannel?} The feedback thread if it exists, or null if invalid.
  */
 async function getFeedbackThreadFromInteraction(interaction) {
-    if (interaction.channel.parentId != getFeedbackChannelId()) return null;
+    const feedback_channel_id = await getFeedbackChannelId();
+    if (interaction.channel.parentId != feedback_channel_id) return null;
     return interaction.channel;
 }
 
@@ -19,7 +20,8 @@ async function getFeedbackThreadFromInteraction(interaction) {
  * @returns {string?} 
  */
 async function getFeedbackThreadOwnerId(thread) {
-    if (thread.parentId != getFeedbackChannelId()) return null;
+    const feedback_channel_id = await getFeedbackChannelId();
+    if (thread.parentId != feedback_channel_id) return null;
     return thread.ownerId;
 }
 

--- a/helpers/contractMethods.js
+++ b/helpers/contractMethods.js
@@ -1,14 +1,29 @@
-const { Interaction } = require('discord.js');
+const { ThreadChannel } = require('discord.js');
 const { getFeedbackChannelId } = require('./settingsMethods');
 
 /**
  * Gets whether an interaction occurred within a feedback thread. Returns the
- * feedback thread ID, or `null` if the interaction happened outside of a
+ * feedback thread, or `null` if the interaction happened outside of a
  * designated feedback thread.
- * @param {Interaction} interaction 
- * @returns {string?} The feedback thread ID if it exists, or null if invalid.
+ * @param {import('discord.js').Interaction} interaction The interaction.
+ * @returns {ThreadChannel?} The feedback thread if it exists, or null if invalid.
  */
 async function getFeedbackThreadFromInteraction(interaction) {
     if (interaction.channel.parentId != getFeedbackChannelId()) return null;
-    return interaction.channel.id;
+    return interaction.channel;
+}
+
+/**
+ * Gets the owner ID of a feedback threadm or `null` if not a feedback thread.
+ * @param {ThreadChannel} thread The thread.
+ * @returns {string?} 
+ */
+async function getFeedbackThreadOwnerId(thread) {
+    if (thread.parentId != getFeedbackChannelId()) return null;
+    return thread.ownerId;
+}
+
+module.exports = {
+    getFeedbackThreadFromInteraction,
+    getFeedbackThreadOwnerId,
 }

--- a/helpers/contractMethods.js
+++ b/helpers/contractMethods.js
@@ -15,7 +15,7 @@ async function getFeedbackThreadFromInteraction(interaction) {
 }
 
 /**
- * Gets the owner ID of a feedback threadm or `null` if not a feedback thread.
+ * Gets the owner ID of a feedback thread or `null` if not a feedback thread.
  * @param {ThreadChannel} thread The thread.
  * @returns {string?} 
  */

--- a/helpers/contractMethods.js
+++ b/helpers/contractMethods.js
@@ -17,7 +17,7 @@ async function getFeedbackThreadFromInteraction(interaction) {
 /**
  * Gets the owner ID of a feedback thread or `null` if not a feedback thread.
  * @param {ThreadChannel} thread The thread.
- * @returns {string?} 
+ * @returns {string?} The user ID of the thread owner.
  */
 async function getFeedbackThreadOwnerId(thread) {
     const feedback_channel_id = await getFeedbackChannelId();

--- a/helpers/contractMethods.js
+++ b/helpers/contractMethods.js
@@ -1,0 +1,14 @@
+const { Interaction } = require('discord.js');
+const { getFeedbackChannelId } = require('./settingsMethods');
+
+/**
+ * Gets whether an interaction occurred within a feedback thread. Returns the
+ * feedback thread ID, or `null` if the interaction happened outside of a
+ * designated feedback thread.
+ * @param {Interaction} interaction 
+ * @returns {string?} The feedback thread ID if it exists, or null if invalid.
+ */
+async function getFeedbackThreadFromInteraction(interaction) {
+    if (interaction.channel.parentId != getFeedbackChannelId()) return null;
+    return interaction.channel.id;
+}


### PR DESCRIPTION
Added `helpers/contractMethods.js`
* `getFeedbackThreadFromInteraction(Interaction)`: Returns the feedback thread an interaction occurred in, or `null` if not a valid feedback thread.
* `getFeedbackThreadOwnerId(ThreadChannel?)`: Returns the owner of the feedback thread, or `null` if not a valid feedback thread.

Added a `/contract getinfo` command that displays info about the current active feedback thread, or prints an error message if used outside a feedback thread. Currently, this only displays the feedback thread owner, but more features can be added later.

Added a `ping` option to `/contract create` that pings the feedback thread owner within the contract message.

Added a check to prevent `/contract` commands from being used outside feedback threads.

Closes #22, Closes #23